### PR TITLE
add missing _mb postfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The `vm.swappiness` value to be configured in sysconfig.
 
 If you wish to _remove_ your swapfile, and disable swap, set this to `absent`. Generally you'd probably want to set this to `present`.
 
-    swap_file_create_command: "dd if=/dev/zero of={{ swap_file_path }} bs=1M count={{ swap_file_size }}"
+    swap_file_create_command: "dd if=/dev/zero of={{ swap_file_path }} bs=1M count={{ swap_file_size_mb }}"
 
 The command used to create the swap file. You could switch to using `fallocate` to write the swap file more quickly, though there may be inconsistencies if not writing the file with `dd`.
 


### PR DESCRIPTION
The swap_file_create_command configuration example should have `count={{ swap_file_size_b }}` instead of `count={{ swap_file_size }}`