### PR TITLE
fix int to string warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The location of the swap file on the server.
 
 How large (in megabytes) to make the swap file.
 
-    swap_swappiness: 60
+    swap_swappiness: '60'
 
 The `vm.swappiness` value to be configured in sysconfig.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 swap_file_path: /swapfile
 swap_file_size_mb: '512'
-swap_swappiness: 60
+swap_swappiness: '60'
 swap_file_state: present
 swap_file_create_command: "dd if=/dev/zero of={{ swap_file_path }} bs=1M count={{ swap_file_size_mb }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,8 +5,6 @@
     src: "{{ swap_file_path }}"
     fstype: swap
     opts: sw
-    passno: 0
-    dump: 0
     state: "{{ swap_file_state }}"
 
 - include_tasks: disable.yml


### PR DESCRIPTION
Ansible shows warning like this for `passno`, `dump` parameters of `mount`, and the swappiness value:

```
[WARNING]: The value 0 (type int) in a string field was converted to '0' (type string). If this does not
look like what you expect, quote the entire value to ensure it does not change.

```

Looks like `passno` and `dump` have the same defaults, so I removed them. https://docs.ansible.com/ansible/latest/modules/mount_module.html