### PR TITLE
Asynchronously create swap file

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ If you wish to _remove_ your swapfile, and disable swap, set this to `absent`. G
 
 The command used to create the swap file. You could switch to using `fallocate` to write the swap file more quickly, though there may be inconsistencies if not writing the file with `dd`.
 
+Timeout (in seconds) on the creation of the swap file.
+
+    swap_file_create_timeout_in_seconds: 3600
+
+Period (in seconds) between checks on if the swap file has been created .
+
+    swap_file_create_poll_period_in_seconds: 5
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,5 +4,7 @@ swap_file_size_mb: '512'
 swap_swappiness: '60'
 swap_file_state: present
 swap_file_create_command: "dd if=/dev/zero of={{ swap_file_path }} bs=1M count={{ swap_file_size_mb }}"
+swap_file_create_timeout_in_seconds: 3600
+swap_file_create_poll_period_in_seconds: 5
 
 swap_test_mode: false

--- a/tasks/enable.yml
+++ b/tasks/enable.yml
@@ -3,6 +3,8 @@
   command: >
     {{ swap_file_create_command }}
     creates='{{ swap_file_path }}'
+  async: "{{ swap_file_create_timeout_in_seconds }}"
+  poll: "{{ swap_file_create_poll_period_in_seconds }}"
   register: swap_file_create
 
 - name: Set permissions on swap file.


### PR DESCRIPTION
As described in the README, `dd` can take a long time to create the swap file, particularly if it is large or the role is being used on a low powered device (e.g. an rpi).

The problem this causes is that the operation takes longer than the SSH timeout and it dies partway through (which leaves an unfinished swap file in place that is not detected in a subsequent run but that's another issue...):
```
TASK [geerlingguy.swap : Ensure swap file exists.] **************************************************************************************************************************************************task path: /etc/ansible/roles/geerlingguy.swap/tasks/enable.yml:2
fatal: [xxx]: UNREACHABLE! => {
    "changed": false,
    "msg": "Failed to connect to the host via ssh: Shared connection to x.x.x.x closed.",
    "unreachable": true
}
```

To get around this problem, this PR makes the long running creation task asynchronous (https://docs.ansible.com/ansible/latest/user_guide/playbooks_async.html).