### PR TITLE
Allow swap mount options to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ If you wish to _remove_ your swapfile, and disable swap, set this to `absent`. G
 
 The command used to create the swap file. You could switch to using `fallocate` to write the swap file more quickly, though there may be inconsistencies if not writing the file with `dd`.
 
+Mount options for the swap file entry in fstab can be customised.
+
+    swap_mount_opts: sw
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,5 +4,6 @@ swap_file_size_mb: '512'
 swap_swappiness: '60'
 swap_file_state: present
 swap_file_create_command: "dd if=/dev/zero of={{ swap_file_path }} bs=1M count={{ swap_file_size_mb }}"
+swap_mount_opts: sw
 
 swap_test_mode: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
     name: none
     src: "{{ swap_file_path }}"
     fstype: swap
-    opts: sw
+    opts: "{{ swap_mount_opts }}"
     state: "{{ swap_file_state }}"
 
 - include_tasks: disable.yml


### PR DESCRIPTION
This PR allows users of the role to configure the mount options for the swap file entry in fstab.

The use-case I was interested in was added the "nofail" option to increase boot resilience. For example, "nofail" will stop the boot from failing if the swap destination is a mounted device that itself fails to mount.

I've made the solution general to allow for any types of mount opts to be set.
