### PR TITLE
* Readme: Fix documentation: swap file size is in mebibytes, not megabytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The location of the swap file on the server.
 
     swap_file_size_mb: '512'
 
-How large (in megabytes) to make the swap file.
+How large (in mebibytes) to make the swap file.
 
     swap_swappiness: '60'
 


### PR DESCRIPTION
See `man dd`

> bs=BYTES

```
N and BYTES may be followed by the following multiplicative suffixes:
c =1, w =2, b =512, kB =1000, K =1024, MB =1000*1000, M =1024*1024, xM =M,
GB =1000*1000*1000, G =1024*1024*1024, and so on for T, P, E, Z, Y.
```

`bs=1M` means mebibytes, `bs=1MB` = megabytes.