### PR TITLE
Tweak swapoff behaviour

### DIFF
--- a/tasks/disable.yml
+++ b/tasks/disable.yml
@@ -2,6 +2,7 @@
 - name: Disable swap (if configured).
   command: swapoff -a
   tags: ['skip_ansible_lint']
+  when: ansible_swaptotal_mb > 0
 
 - name: Ensure swap file doesn't exist (if configured).
   file:


### PR DESCRIPTION
If swap is disabled then "swapoff -a"  always runs, which results in a "changed" report every time.  Adding in the conditional when the swap is bigger than zero avoids this.
Putting it here rather than in main.yml means that it'll still make sure the swapfile is gone.

P.S. Thanks for providing things via ansible galaxy, using a few of your roles already!