### PR TITLE
dynamically adjust swap file size

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,5 +1,5 @@
 ---
-- name: Converge
+- name: Initial
   hosts: all
   become: true
 
@@ -11,6 +11,28 @@
     - name: Update apt cache.
       apt: update_cache=true cache_valid_time=600
       when: ansible_os_family == 'Debian'
+
+  roles:
+    - role: geerlingguy.swap
+
+- name: Grow
+  hosts: all
+  become: true
+
+  vars:
+    swap_file_size_mb: '512'
+    swap_test_mode: true
+
+  roles:
+    - role: geerlingguy.swap
+
+- name: Shrink
+  hosts: all
+  become: true
+
+  vars:
+    swap_file_size_mb: '256'
+    swap_test_mode: true
 
   roles:
     - role: geerlingguy.swap

--- a/tasks/enable.yml
+++ b/tasks/enable.yml
@@ -1,9 +1,45 @@
 ---
+
+- name: Stat swap file
+  stat:
+    path: "{{ swap_file_path }}"
+    follow: true
+  register: 'swap_file'
+
+- name: Fail if swapfile exists but is not a regular file.
+  ansible.builtin.fail:
+    msg: "Swap file {{ swap_file_path }} exists but is neither a regular file nor a symlink to a regular file."
+  when:
+    - swap_file.stat.exists
+    - not swap_file.stat.isreg
+
+- name: Read used swapfiles.
+  read_csv:
+    path: '/proc/swaps'
+    key: 'file'
+    fieldnames: [ 'file' ]
+    delimiter: ' '
+  register: swapfiles
+
+- name: Disable swapfile before size change.
+  command: "swapoff {{ swap_file_path }}"
+  register: swap_file_size_change
+  when:
+    - swap_file.stat.exists
+    - swap_file_path in swapfiles.dict
+    - 'swap_file.stat.size != swap_file_size_mb * 1024 * 1024'
+
 - name: Ensure swap file exists.
-  command: >
-    {{ swap_file_create_command }}
-    creates='{{ swap_file_path }}'
+  command: "{{ swap_file_create_command }}"
   register: swap_file_create
+  when: not swap_file.stat.exists or swap_file.stat.size < swap_file_size_mb|int * 1024 * 1024
+
+- name: Ensure swap file is not too large.
+  command: "truncate -s {{ swap_file_size_mb }}M {{ swap_file_path }}"
+  register: swap_file_shrink
+  when:
+    - swap_file.stat.exists
+    - swap_file.stat.size > swap_file_size_mb|int * 1024 * 1024
 
 - name: Set permissions on swap file.
   file:
@@ -14,7 +50,7 @@
 
 - name: Make swap file if necessary.
   command: mkswap {{ swap_file_path }}
-  when: swap_file_create is changed
+  when: swap_file_create is changed or swap_file_shrink is changed
   register: mkswap_result
 
 - name: Run swapon on the swap file.


### PR DESCRIPTION
- swapfile is `stat()`ed
- state is checked for sanity
- /proc/swaps is read
	- side note: at least on my system the headers seem to be tab delimitted and the rest to be mixed tabs and spaces, which is why the corresponding code is weird
- if the swapfile is currently in use it is swapoff'd (swapoff -e proved to be not widespread enough)
- size is checked
	- if too small or file does not exist, dd
	- if too big, truncate
- if either of the above commands ran, mkswap
- proceed as usual

---

The above is the commit message body.
So when it comes to testing it looks like you aren't actually testing the execution, presumably due to container runtime limitations?
I myself don't know a good way to test this any further besides checking for the filesize in-between steps that however I don't know how to do.

Any suggestions or comments are very welcome.
