### PR TITLE
Adds vfs_cache_pressure

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 swap_file_path: /swapfile
 swap_file_size_mb: '512'
 swap_swappiness: '60'
+swap_vfs_cache_pressure: '50'
 swap_file_state: present
 swap_file_create_command: "dd if=/dev/zero of={{ swap_file_path }} bs=1M count={{ swap_file_size_mb }}"
 

--- a/tasks/enable.yml
+++ b/tasks/enable.yml
@@ -28,3 +28,9 @@
     name: vm.swappiness
     value: "{{ swap_swappiness }}"
     state: present
+
+- name: Set vfs_cache_pressure
+  sysctl:
+    name: vm.vfs_cache_pressure
+    value: "{{ swap_vfs_cache_pressure }}"
+    state: present


### PR DESCRIPTION
This PR adds `vfs_cache_pressure` which is set in `/etc/sysctl.conf` as `vm.vfs_cache_pressure=<value>`.

> **vfs_cache_pressure** this variable controls the tendency of the kernel to reclaim the memory which is used for caching of VFS caches, versus pagecache and swap. Increasing this value increases the rate at which VFS caches are reclaimed.