### PR TITLE
Disable Swappiness when Swap is Disabled

### DIFF
--- a/tasks/disable.yml
+++ b/tasks/disable.yml
@@ -7,3 +7,9 @@
   file:
     path: "{{ swap_file_path }}"
     state: absent
+
+- name: Disable swappiness.
+  sysctl:
+    name: vm.swappiness
+    value: 0
+    state: present


### PR DESCRIPTION
All of the recommendations I have seen is to set `vm.swappiness` to `0` when swap is disabled.