### PR TITLE
Attempts to Resize Existing Swap File

### DIFF
--- a/tasks/check-size.yml
+++ b/tasks/check-size.yml
@@ -1,0 +1,13 @@
+---
+- name: Check if swap file exists
+  stat:
+    path: "{{ swap_file_path }}"
+    get_checksum: false
+    get_md5: false
+  register: swap_file_check
+  changed_when: false
+
+- name: Set variable for existing swap file size
+  set_fact:
+    swap_file_existing_size_mb: "{{ (swap_file_check.stat.size / 1024 / 1024) | int }}"
+  when: swap_file_check.stat.exists

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,8 +7,12 @@
     opts: sw
     state: "{{ swap_file_state }}"
 
+- include_tasks: check-size.yml
+  when: swap_file_state == 'present'
+
 - include_tasks: disable.yml
   when: swap_file_state == 'absent'
+    or (swap_file_state == 'present' and swap_file_existing_size_mb != swap_file_size_mb)
 
 - include_tasks: enable.yml
   when: swap_file_state == 'present'


### PR DESCRIPTION
If the size of the swap file is different than the configuration, it attempts to disable swap, and recreates it with the new size.

Resolves #22