### PR TITLE
Set default swap file size when file doesn't exist

### DIFF
--- a/tasks/check-size.yml
+++ b/tasks/check-size.yml
@@ -10,3 +10,8 @@
   set_fact:
     swap_file_existing_size_mb: "{{ (swap_file_check.stat.size / 1024 / 1024) | int }}"
   when: swap_file_check.stat.exists
+
+- name: Set default value for existing swap file size when it doesn't exist
+  set_fact:
+    swap_file_existing_size_mb: 0
+  when: not swap_file_check.stat.exists


### PR DESCRIPTION
Fixes #33 and #34 

The current version of the role fails when a swap file does not already exist, which causes the variable of `swap_file_existing_size_mb` to not be set. Thix fix sets the fact to `0` if the file doesn't exist, allowing the conditional check to pass and the playbook to complete.