### PR TITLE
Make setting vm.swappiness optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ How large (in mebibytes) to make the swap file.
 
     swap_swappiness: '60'
 
-The `vm.swappiness` value to be configured in sysconfig.
+The `vm.swappiness` value to be configured in sysconfig. To keep the current `vm.swappiness` set this to a YAML null value (e.g. `swap_swappiness: null`).
 
     swap_file_state: present
 

--- a/tasks/enable.yml
+++ b/tasks/enable.yml
@@ -28,3 +28,4 @@
     name: vm.swappiness
     value: "{{ swap_swappiness }}"
     state: present
+  when: swap_swappiness is defined and swap_swappiness|int


### PR DESCRIPTION
There wasn't a way to keep target systems' current `vm.swappiness` setting/value so here's a minimal patch to allow *not* setting/changing this value.