### PR TITLE
Add swap_options to set mount options

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ How large (in mebibytes) to make the swap file.
 
     swap_swappiness: '60'
 
+The mount options to use for the swap file.
+
+    swap_options: sw
+
 The `vm.swappiness` value to be configured in sysconfig.
 
     swap_file_state: present

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,5 +4,6 @@ swap_file_size_mb: '512'
 swap_swappiness: '60'
 swap_file_state: present
 swap_file_create_command: "dd if=/dev/zero of={{ swap_file_path }} bs=1M count={{ swap_file_size_mb }}"
+swap_options: sw
 
 swap_test_mode: false

--- a/tasks/enable.yml
+++ b/tasks/enable.yml
@@ -18,7 +18,7 @@
   register: mkswap_result
 
 - name: Run swapon on the swap file.
-  command: swapon {{ swap_file_path }}
+  command: swapon -o {{ swap_options }} {{ swap_file_path }}
   when:
     - mkswap_result is changed
     - not swap_test_mode

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
     name: none
     src: "{{ swap_file_path }}"
     fstype: swap
-    opts: sw
+    opts: "{{ swap_options }}"
     state: "{{ swap_file_state }}"
 
 - include_tasks: check-size.yml


### PR DESCRIPTION
Adds a `swap_options` variable defaulting to "sw" to preserve the current behaviour. This is used to set the options field in `/etc/fstab` and also passed to the initial `swapon`.

The latter means that this change won't work on, for example, Alpine systems with just BusyBox installed, it requires a full-fat version of `swapon` from `util-linux-misc`. I can back out that second part, or conditionalise it as `swap_swapon_options` vs. `swap_mount_options` if you prefer. As Alpine isn't marked as a supported distribution for the role, though, you may not regard it as a problem.

Resolves #40.
