### PR TITLE
Allow using with Btrfs by replacing command with shell

### DIFF
--- a/tasks/enable.yml
+++ b/tasks/enable.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure swap file exists.
-  command: >
+  shell: >
     {{ swap_file_create_command }}
     creates='{{ swap_file_path }}'
   register: swap_file_create


### PR DESCRIPTION
This is a continuation of #29 and paves the road towards #28.

Example usage: (almost the same as the example in #29, just change swap_file_size_mb from a string to a number)
```
swap_file_size_mb: 1024
swap_file_create_command: "truncate -s 0 {{ swap_file_path }} && chattr +C {{ swap_file_path }} && fallocate -l {{ swap_file_size_mb }}MiB {{ swap_file_path }}"
```