### PR TITLE
Fix documentation to prevent swap recreation on every rerun

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Available variables are listed below, along with default values (see `defaults/m
 
 The location of the swap file on the server.
 
-    swap_file_size_mb: '512'
+    swap_file_size_mb: 512
 
 How large (in mebibytes) to make the swap file.
 


### PR DESCRIPTION
If swap size specified as string, comparison with current size fails and swap got disabled and recreated every run. This is because size in code is set with filter ' | int', and documentation tells to use strings. This pull request corrects docs.