### PR TITLE
Fix swap idempotency

### DIFF
--- a/tasks/check-size.yml
+++ b/tasks/check-size.yml
@@ -13,5 +13,5 @@
 
 - name: Set default value for existing swap file size when it doesn't exist
   set_fact:
-    swap_file_existing_size_mb: "{{ swap_file_size_mb }}"
+    swap_file_existing_size_mb: 0
   when: not swap_file_check.stat.exists

--- a/tasks/enable.yml
+++ b/tasks/enable.yml
@@ -1,8 +1,8 @@
 ---
 - name: Ensure swap file exists.
-  command: >
-    {{ swap_file_create_command }}
-    creates='{{ swap_file_path }}'
+  command: "{{ swap_file_create_command }}"
+  args:
+    creates: "{{ swap_file_path }}"
   register: swap_file_create
 
 - name: Set permissions on swap file.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - include_tasks: disable.yml
   when: swap_file_state == 'absent'
-    or (swap_file_state == 'present' and swap_file_existing_size_mb != swap_file_size_mb)
+    or (swap_file_state == 'present' and (swap_file_existing_size_mb | int) != (swap_file_size_mb | int))
 
 - include_tasks: enable.yml
   when: swap_file_state == 'present'


### PR DESCRIPTION
Fixes non-idempotent swap file recreation by
1. moving the swap file create guard from inside the command string (`creates='...'`) into the command module `args.creates` so Ansible can skip the task when the file already exists,
2. enforcing integer comparison of the existing vs desired swap sizes to avoid string/int mismatches causing unnecessary disable/enable cycles, and
3. setting `swap_file_existing_size_mb` to `0` (instead of the desired size) when the swap file is absent so state detection is accurate.

Together these changes make the role only (re)create and reinitialize the swap file when its size actually changes or it is missing, restoring full idempotency.