### PR TITLE
Disable specified swap file only

### DIFF
--- a/tasks/disable.yml
+++ b/tasks/disable.yml
@@ -1,6 +1,8 @@
 ---
 - name: Disable swap (if configured).
-  command: swapoff -a
+  command: "swapoff {{ swap_file_path }}"
+  args:
+    removes: "{{ swap_file_path }}"
   when:
     - ansible_facts.memory_mb['swap']['total'] > 0
     - not swap_test_mode


### PR DESCRIPTION
Previously the role disabled swap completely, which made it unusable on systems with multiple swap files.