### PR TITLE
Persist swappiness in sysctl.d

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ How large (in mebibytes) to make the swap file.
 
 The `vm.swappiness` value to be configured in sysconfig.
 
+    swap_sysctl_file: /etc/sysctl.d/90-swap.conf
+
+The sysctl file used to persist `vm.swappiness`.
+
     swap_file_state: present
 
 If you wish to _remove_ your swapfile, and disable swap, set this to `absent`. Generally you'd probably want to set this to `present`.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 swap_file_path: /swapfile
 swap_file_size_mb: '512'
 swap_swappiness: '60'
+swap_sysctl_file: /etc/sysctl.d/90-swap.conf
 swap_file_state: present
 swap_file_create_command: "dd if=/dev/zero of={{ swap_file_path }} bs=1M count={{ swap_file_size_mb }}"
 

--- a/tasks/enable.yml
+++ b/tasks/enable.yml
@@ -29,3 +29,5 @@
     name: vm.swappiness
     value: "{{ swap_swappiness }}"
     state: present
+    sysctl_set: true
+    sysctl_file: "{{ swap_sysctl_file }}"


### PR DESCRIPTION
Persist `vm.swappiness` in a dedicated `sysctl.d` drop-in instead of `/etc/sysctl.conf`.

On Debian 13 (Trixie), `/etc/sysctl.conf` is no longer honored by `systemd-sysctl`, so persisting `vm.swappiness` there may not survive reboot:
https://www.debian.org/releases/stable/release-notes/issues.en.html#etc-sysctl-conf-is-no-longer-honored

`ansible.posix` has documented this behaviour, but the sysctl module still defaults to `/etc/sysctl.conf`: https://github.com/ansible-collections/ansible.posix/pull/745