### PR TITLE
fix: add async/poll to swap file creation task to prevent SSH timeout

### DIFF
--- a/tasks/enable.yml
+++ b/tasks/enable.yml
@@ -4,6 +4,8 @@
   args:
     creates: "{{ swap_file_path }}"
   register: swap_file_create
+  async: 3600
+  poll: 15
 
 - name: Set permissions on swap file.
   file:


### PR DESCRIPTION
**Problem**
When creating large swap files (e.g. 16GB+), the _Ensure swap file exists_ task hangs indefinitely. The root cause is SSH connection drop (Broken pipe on mux channel) during long-running `dd` command, causing Ansible to lose the exit code and stall.
Reproduces reliably on hosts connected via ProxyJump with ControlPersist.

**Changes**
Added async: 3600 and poll: 15 to the Ensure swap file exists shell task. This runs the command as a background job on the remote host and polls for completion every 15 seconds, making the task resilient to SSH channel interruptions.
Testing

Tested on Ubuntu 24.04 with 16GB swap file via ProxyJump host
Verified creates: idempotency still works correctly on repeated runs