### PR TITLE
Fix change reported idempotency setting swappiness

### DIFF
--- a/tasks/enable.yml
+++ b/tasks/enable.yml
@@ -29,3 +29,4 @@
     name: vm.swappiness
     value: "{{ swap_swappiness }}"
     state: present
+    reload: false


### PR DESCRIPTION
Previously, setting the swapiness was always reporting a change. The sysctl module defaults to reloading (aka running `sysctl -p /etc/sysctl.conf`) before checking set values. The unconditional reload operation causes systctl to report a change. Avoid this problem by disabling reload, which causes the module to only update the config file when the value has actually changed.